### PR TITLE
Regenerate civix file to fix compatability with php7.4

### DIFF
--- a/notepermissions.civix.php
+++ b/notepermissions.civix.php
@@ -7,9 +7,9 @@
  * extension.
  */
 class CRM_Notepermissions_ExtensionUtil {
-  const SHORT_NAME = "notepermissions";
-  const LONG_NAME = "eu.businessandcode.notepermissions";
-  const CLASS_PREFIX = "CRM_Notepermissions";
+  const SHORT_NAME = 'notepermissions';
+  const LONG_NAME = 'eu.businessandcode.notepermissions';
+  const CLASS_PREFIX = 'CRM_Notepermissions';
 
   /**
    * Translate a string using the extension's domain.
@@ -193,8 +193,9 @@ function _notepermissions_civix_civicrm_disable() {
  * @param $op string, the type of operation being performed; 'check' or 'enqueue'
  * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
  *
- * @return mixed  based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *                for 'enqueue', returns void
+ * @return mixed
+ *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
+ *   for 'enqueue', returns void
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
@@ -220,41 +221,18 @@ function _notepermissions_civix_upgrader() {
  * Search directory tree for files which match a glob pattern.
  *
  * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
- * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
+ * Note: Delegate to CRM_Utils_File::findFiles(), this function kept only
+ * for backward compatibility of extension code that uses it.
  *
  * @param string $dir base dir
  * @param string $pattern , glob pattern, eg "*.txt"
  *
- * @return array(string)
+ * @return array
  */
 function _notepermissions_civix_find_files($dir, $pattern) {
-  if (is_callable(['CRM_Utils_File', 'findFiles'])) {
-    return CRM_Utils_File::findFiles($dir, $pattern);
-  }
-
-  $todos = [$dir];
-  $result = [];
-  while (!empty($todos)) {
-    $subdir = array_shift($todos);
-    foreach (_notepermissions_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
-        $result[] = $match;
-      }
-    }
-    if ($dh = opendir($subdir)) {
-      while (FALSE !== ($entry = readdir($dh))) {
-        $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
-        }
-        elseif (is_dir($path)) {
-          $todos[] = $path;
-        }
-      }
-      closedir($dh);
-    }
-  }
-  return $result;
+  return CRM_Utils_File::findFiles($dir, $pattern);
 }
+
 /**
  * (Delegated) Implements hook_civicrm_managed().
  *
@@ -362,7 +340,7 @@ function _notepermissions_civix_civicrm_themes(&$themes) {
  * @link http://php.net/glob
  * @param string $pattern
  *
- * @return array, possibly empty
+ * @return array
  */
 function _notepermissions_civix_glob($pattern) {
   $result = glob($pattern);
@@ -470,8 +448,6 @@ function _notepermissions_civix_civicrm_alterSettingsFolders(&$metaDataFolders =
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
  */
-
 function _notepermissions_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes = array_merge($entityTypes, array (
-  ));
+  $entityTypes = array_merge($entityTypes, []);
 }


### PR DESCRIPTION
The team I am recently deployed this extension onto a server running PHP7.4 and got the following notices

```
PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in /xxx/uploads/civicrm/ext/eu.businessandcode.notepermissions/notepermissions.civix.php on line 247
Deprecated: Array and string offset access syntax with curly braces is deprecated in /xxx/uploads/civicrm/ext/eu.businessandcode.notepermissions/notepermissions.civix.php on line 247
````

ping @AlainBenbassat 