### PR TITLE
Update selectWhereClause hook

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -13,8 +13,8 @@
     <url desc="Documentation">https://github.com/AlainBenbassat/eu.businessandcode.notepermissions/blob/master/README.md</url>
     <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2021-11-18</releaseDate>
-  <version>1.1</version>
+  <releaseDate>2023-11-09</releaseDate>
+  <version>1.2</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.0</ver>

--- a/info.xml
+++ b/info.xml
@@ -14,7 +14,7 @@
     <url desc="Licensing">https://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
   <releaseDate>2023-11-09</releaseDate>
-  <version>1.2</version>
+  <version>1.2.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.0</ver>

--- a/notepermissions.php
+++ b/notepermissions.php
@@ -9,7 +9,6 @@ function notepermissions_civicrm_notePrivacy(&$noteValues) {
   if ($noteValues['privacy'] >= 2) {
     // get the corresponding permission key
     list($permissionKey, $permissionName, $permissionDescription) = notepermissions_civicrm_getPermissionNameAndDescription($noteValues['privacy'], '');
-
     // check if the current user is allowed to see the note
     if (CRM_Core_Permission::check($permissionKey)) {
       // OK, unhide the note
@@ -21,7 +20,11 @@ function notepermissions_civicrm_notePrivacy(&$noteValues) {
 /**
  * Implements hook_civicrm_selectWhereClause().
  */
-function notepermissions_civicrm_selectWhereClause($entityName, &$clauses, $userId) {
+function notepermissions_civicrm_selectWhereClause($entityName, &$clauses, $userId = 0, $conditions = []) {
+  if ($userId === 0) {
+    $userId = CRM_Core_Session::getLoggedInContactID();
+  }
+
   // Amend note privacy clause (only relevant if user lacks 'view all notes' permission)
   if ($entityName === 'Note' && !CRM_Core_Permission::check('view all notes', $userId)) {
     $options = \Civi\Api4\OptionValue::get(FALSE)

--- a/notepermissions.php
+++ b/notepermissions.php
@@ -20,7 +20,7 @@ function notepermissions_civicrm_notePrivacy(&$noteValues) {
 /**
  * Implements hook_civicrm_selectWhereClause().
  */
-function notepermissions_civicrm_selectWhereClause($entityName, &$clauses, $userId = 0, $conditions = []) {
+function notepermissions_civicrm_selectWhereClause($entityName, &$clauses, $userId = NULL, $conditions = []) {
   if ($userId === 0) {
     $userId = CRM_Core_Session::getLoggedInContactID();
   }
@@ -28,6 +28,7 @@ function notepermissions_civicrm_selectWhereClause($entityName, &$clauses, $user
   // Amend note privacy clause (only relevant if user lacks 'view all notes' permission)
   if ($entityName === 'Note' && !CRM_Core_Permission::check('view all notes', $userId)) {
     $options = \Civi\Api4\OptionValue::get(FALSE)
+      ->addSelect('value')
       ->addWhere('option_group_id:name', '=', 'note_privacy')
       ->addWhere('value', '>', 1)
       ->execute()
@@ -39,8 +40,8 @@ function notepermissions_civicrm_selectWhereClause($entityName, &$clauses, $user
         // (which means OR).
         // @see CRM_Core_BAO_Note::addSelectWhereClause()
         // The existing values are `"= 0" OR "= 1 AND {contact_id} = $currentUser"`
-        // So here we are adding a 3rd condition IF the above permission check passes, to allow
-        // our privileged users to see our special privacy type 2.
+        // So here we are adding a condition to the OR group IF the above permission check passes,
+        // to allow privileged users to see this privacy type.
         $clauses['privacy'][0][] = "= $optionValue";
       }
     }


### PR DESCRIPTION
The primary purpose of this change is to correct the default value for `$userId` which should be NULL to indicate "current user".
Additionally added a few updates to the code comments & a select clause to the APIv4 query for performance.

See https://github.com/AlainBenbassat/eu.businessandcode.notepermissions/issues/3#issuecomment-1809371137